### PR TITLE
Fixed admin-state and subnets

### DIFF
--- a/os_resources_ui/static/app/resources/os-neutron-nets/drawer.html
+++ b/os_resources_ui/static/app/resources/os-neutron-nets/drawer.html
@@ -9,9 +9,6 @@
   </dl>
   <dl class="col-md-4">
     <hz-property
-      prop-name="subnets" resource-type-name="OS::Neutron::Net" item="item"
-    ></hz-property>
-    <hz-property
       prop-name="shared" resource-type-name="OS::Neutron::Net" item="item"
     ></hz-property>
     <hz-property
@@ -23,7 +20,7 @@
       prop-name="status" resource-type-name="OS::Neutron::Net" item="item"
     ></hz-property>
     <hz-property
-      prop-name="admin_state" resource-type-name="OS::Neutron::Net" item="item"
+      prop-name="admin_state_up" resource-type-name="OS::Neutron::Net" item="item"
     ></hz-property>
   </dl>
 </div>

--- a/os_resources_ui/static/app/resources/os-neutron-nets/os-neutron-nets.module.js
+++ b/os_resources_ui/static/app/resources/os-neutron-nets/os-neutron-nets.module.js
@@ -71,11 +71,11 @@
           "ERROR": gettext('Error')
         }
       })
-      .setProperty('admin_state', {
+      .setProperty('admin_state_up', {
         label: gettext('Admin State'),
         values: {
-          "UP": gettext('Up'),
-          "DOWN": gettext('Down')
+          true: gettext('Up'),
+          false: gettext('Down')
         }
       })
       .setListFunction(listFunction)
@@ -104,7 +104,7 @@
         priority: 2
       })
       .append({
-        id: 'admin_state',
+        id: 'admin_state_up',
         priority: 2
       });
 

--- a/os_resources_ui/static/app/resources/os-neutron-ports/drawer.html
+++ b/os_resources_ui/static/app/resources/os-neutron-ports/drawer.html
@@ -23,7 +23,7 @@
       prop-name="status" resource-type-name="OS::Neutron::Port" item="item"
     ></hz-property>
     <hz-property
-      prop-name="admin_state" resource-type-name="OS::Neutron::Port" item="item"
+      prop-name="admin_state_up" resource-type-name="OS::Neutron::Port" item="item"
     ></hz-property>
   </dl>
 </div>

--- a/os_resources_ui/static/app/resources/os-neutron-ports/os-neutron-ports.module.js
+++ b/os_resources_ui/static/app/resources/os-neutron-ports/os-neutron-ports.module.js
@@ -72,11 +72,11 @@
           "ERROR": gettext('Error')
         }
       })
-      .setProperty('admin_state', {
+      .setProperty('admin_state_up', {
         label: gettext('Admin State'),
         values: {
-          "UP": gettext('Up'),
-          "DOWN": gettext('Down')
+          true: gettext('Up'),
+          false: gettext('Down')
         }
       })
       .setListFunction(listFunction)
@@ -101,7 +101,7 @@
         priority: 2
       })
       .append({
-        id: 'admin_state',
+        id: 'admin_state_up',
         priority: 2
       });
 

--- a/os_resources_ui/static/app/resources/os-neutron-routers/drawer.html
+++ b/os_resources_ui/static/app/resources/os-neutron-routers/drawer.html
@@ -17,7 +17,7 @@
       prop-name="status" resource-type-name="OS::Neutron::Router" item="item"
     ></hz-property>
     <hz-property
-      prop-name="admin_state" resource-type-name="OS::Neutron::Router" item="item"
+      prop-name="admin_state_up" resource-type-name="OS::Neutron::Router" item="item"
     ></hz-property>
   </dl>
 </div>

--- a/os_resources_ui/static/app/resources/os-neutron-routers/os-neutron-router.module.js
+++ b/os_resources_ui/static/app/resources/os-neutron-routers/os-neutron-router.module.js
@@ -63,11 +63,11 @@
           "ERROR": gettext('Error')
         }
       })
-      .setProperty('admin_state', {
+      .setProperty('admin_state_up', {
         label: gettext('Admin State'),
         values: {
-          "UP": gettext('Up'),
-          "DOWN": gettext('Down')
+          true: gettext('Up'),
+          false: gettext('Down')
         }
       })
       .setListFunction(listFunction)
@@ -88,7 +88,7 @@
         priority: 1
       })
       .append({
-        id: 'admin_state',
+        id: 'admin_state_up',
         priority: 2
       });
 


### PR DESCRIPTION
The base API for Neutron doesn't have admin_state but admin_state_up,
and SL doesn't keep .subnets.  Rearranged code to accommodate.
