### PR TITLE
Realigning with new hz-resource-property

### DIFF
--- a/os_resources_ui/static/app/core/instances/details/console.controller.js
+++ b/os_resources_ui/static/app/core/instances/details/console.controller.js
@@ -42,6 +42,16 @@
     ctrl.toldToConnect = false;
     ctrl.connect = connect;
 
+    var fix_height = function() {
+      $('iframe#console_embed').css({ height: $(document).height() + 'px' });
+    };
+    // there are two code paths to this particular block; handle them both
+    if (typeof($) != 'undefined') {
+      $(document).ready(fix_height);
+    } else {
+      addHorizonLoadEvent(fix_height);
+    }
+
     function connect() {
       ctrl.toldToConnect = true;
     }

--- a/os_resources_ui/static/app/core/instances/details/console.html
+++ b/os_resources_ui/static/app/core/instances/details/console.html
@@ -14,17 +14,6 @@
         </div>
         <iframe id="console_embed" ng-src="{$ ctrl.safeUrl $}" style="width:100%;height:100%"></iframe>
       </div>
-      <script type="text/javascript">
-        var fix_height = function() {
-          $('iframe#console_embed').css({ height: $(document).height() + 'px' });
-        };
-        // there are two code paths to this particular block; handle them both
-        if (typeof($) != 'undefined') {
-          $(document).ready(fix_height);
-        } else {
-          addHorizonLoadEvent(fix_height);
-        }
-      </script>
     </div>
     <div class="col-md-12" ng-if="!ctrl.consoleInfo.url">
       <p class="alert alert-danger" translate>Console is currently unavailable. Please try again later.</p>

--- a/os_resources_ui/static/app/core/instances/drawer.html
+++ b/os_resources_ui/static/app/core/instances/drawer.html
@@ -2,31 +2,31 @@
   <div class="col-md-6">
     <dl>
       <dt translate>IP Addresses</dt><dd>{$ ctrl.getAllAddresses(item.addresses) $}</dd>
-      <hz-property
+      <hz-resource-property
         prop-name="status" resource-type-name="OS::Nova::Server" item="item"
-      ></hz-property>
-      <hz-property
+      ></hz-resource-property>
+      <hz-resource-property
         prop-name="key_name" resource-type-name="OS::Nova::Server" item="item"
-      ></hz-property>
-      <hz-property
+      ></hz-resource-property>
+      <hz-resource-property
         prop-name="image_name" resource-type-name="OS::Nova::Server" item="item"
-      ></hz-property>
-      <hz-property
+      ></hz-resource-property>
+      <hz-resource-property
         prop-name="flavor_name" resource-type-name="OS::Nova::Server" item="item"
-      ></hz-property>
+      ></hz-resource-property>
     </dl>
   </div>
   <div class="col-md-6">
     <dl>
-      <hz-property
+      <hz-resource-property
         prop-name="OS-EXT-AZ:availability_zone" resource-type-name="OS::Nova::Server" item="item"
-      ></hz-property>
-      <hz-property
+      ></hz-resource-property>
+      <hz-resource-property
         prop-name="OS-EXT-STS:task_state" resource-type-name="OS::Nova::Server" item="item"
-      ></hz-property>
-      <hz-property
+      ></hz-resource-property>
+      <hz-resource-property
         prop-name="OS-EXT-STS:power_state" resource-type-name="OS::Nova::Server" item="item"
-      ></hz-property>
+      ></hz-resource-property>
     </dl>
   </div>
 </div>

--- a/os_resources_ui/static/app/resources/os-cinder-snapshots/drawer.html
+++ b/os_resources_ui/static/app/resources/os-cinder-snapshots/drawer.html
@@ -1,8 +1,8 @@
-<hz-property-list
+<hz-resource-property-list
   resource-type-name="OS::Cinder::Snapshot"
   item="item"
   property-groups="[
     ['id', 'name', 'description'],
     ['status', 'size'],
     ['volume_id', 'volume_name']]">
-</hz-property-list>
+</hz-resource-property-list>

--- a/os_resources_ui/static/app/resources/os-cinder-volumes/drawer.html
+++ b/os_resources_ui/static/app/resources/os-cinder-volumes/drawer.html
@@ -1,8 +1,8 @@
-<hz-property-list
+<hz-resource-property-list
   resource-type-name="OS::Cinder::Volume"
   item="item"
   property-groups="[
     ['consistencygroup_id', 'source_volid'],
     ['snapshot_id', 'imageRef'],
     ['transfer', 'created_at']]">
-</hz-property-list>
+</hz-resource-property-list>

--- a/os_resources_ui/static/app/resources/os-neutron-floatingip/drawer.html
+++ b/os_resources_ui/static/app/resources/os-neutron-floatingip/drawer.html
@@ -1,7 +1,7 @@
-<hz-property-list
+<hz-resource-property-list
   resource-type-name="OS::Neutron::FloatingIP"
   item="item"
   property-groups="[
     ['ip', 'fixed_ip_address'],
     ['pool', 'status']]">
-</hz-property-list>
+</hz-resource-property-list>

--- a/os_resources_ui/static/app/resources/os-neutron-nets/drawer.html
+++ b/os_resources_ui/static/app/resources/os-neutron-nets/drawer.html
@@ -1,8 +1,8 @@
-<hz-property-list
+<hz-resource-property-list
   resource-type-name="OS::Neutron::Net"
   item="item"
   property-groups="[
    ['name', 'id'],
    ['shared', 'router__external'],
    ['status', 'admin_state_up']]">
-</hz-property-list>
+</hz-resource-property-list>

--- a/os_resources_ui/static/app/resources/os-neutron-ports/drawer.html
+++ b/os_resources_ui/static/app/resources/os-neutron-ports/drawer.html
@@ -1,8 +1,8 @@
-<hz-property-list
+<hz-resource-property-list
   resource-type-name="OS::Neutron::Port"
   item="item"
   property-groups="[
     ['name', 'id'],
     ['fixed_ips', 'device_owner', 'device_id'],
     ['status', 'admin_state_up']]">
-</hz-property-list>
+</hz-resource-property-list>

--- a/os_resources_ui/static/app/resources/os-neutron-routers/drawer.html
+++ b/os_resources_ui/static/app/resources/os-neutron-routers/drawer.html
@@ -1,8 +1,8 @@
-<hz-property-list
+<hz-resource-property-list
   resource-type-name="OS::Neutron::Router"
   item="item"
   property-groups="[
    ['name', 'id'],
    ['external_gateway_info'],
    ['status', 'admin_state_up']]">
-</hz-property-list>
+</hz-resource-property-list>

--- a/os_resources_ui/static/app/resources/os-neutron-securitygroups/drawer.html
+++ b/os_resources_ui/static/app/resources/os-neutron-securitygroups/drawer.html
@@ -1,7 +1,7 @@
-<hz-property-list
+<hz-resource-property-list
   resource-type-name="OS::Neutron::SecurityGroup"
   item="item"
   property-groups="[
    ['name'],
    ['description']]">
-</hz-property-list>
+</hz-resource-property-list>

--- a/os_resources_ui/static/app/resources/os-neutron-subnets/drawer.html
+++ b/os_resources_ui/static/app/resources/os-neutron-subnets/drawer.html
@@ -1,8 +1,8 @@
-<hz-property-list
+<hz-resource-property-list
   resource-type-name="OS::Neutron::Subnet"
   item="item"
   property-groups="[
     ['name', 'id'],
     ['cidr', 'ip_version'],
     ['gateway_ip']]">
-</hz-property-list>
+</hz-resource-property-list>

--- a/os_resources_ui/static/app/resources/os-nova-hypervisors/drawer.html
+++ b/os_resources_ui/static/app/resources/os-nova-hypervisors/drawer.html
@@ -1,8 +1,8 @@
-<hz-property-list
+<hz-resource-property-list
   resource-type-name="OS::Nova::Hypervisor"
   item="item"
   property-groups="[
     ['name', 'id'],
     ['hypervisor_type', 'vcpus', 'local_gb'],
     ['status', 'state']]">
-</hz-property-list>
+</hz-resource-property-list>


### PR DESCRIPTION
Realigning to use hz-resource-property-\* rather than hz-property-*
and also fixing javascript inclusion proble due to template inclusion
causing trouble with embedded script tags.
